### PR TITLE
Fix.MonsterMoving and BossAttackCollider

### DIFF
--- a/VR_Toy_Project/Assets/_PJK/Prefab/MonsterLv1.prefab
+++ b/VR_Toy_Project/Assets/_PJK/Prefab/MonsterLv1.prefab
@@ -227,7 +227,7 @@ MonoBehaviour:
   attackdistance: 2
   distanceToTurret: 0
   detectCollider: {fileID: 3351061256072875355}
-  moveSpeed: 5
+  moveSpeed: 50
   isFindTurret: 0
   isAttackTurret: 0
 --- !u!54 &-8039378715705275072

--- a/VR_Toy_Project/Assets/_PJK/Scene/PJK_Scene.unity
+++ b/VR_Toy_Project/Assets/_PJK/Scene/PJK_Scene.unity
@@ -253,6 +253,7 @@ MonoBehaviour:
   elapsedRate: 0
   currentTime: 0
   gametime: 0
+  spawn: 0
 --- !u!4 &288781996
 Transform:
   m_ObjectHideFlags: 0
@@ -268,6 +269,51 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &390640647
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 390640648}
+  - component: {fileID: 390640649}
+  m_Layer: 8
+  m_Name: AttackCollider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &390640648
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 390640647}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1993261463}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &390640649
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 390640647}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 11.5, y: 1, z: 0.5}
+  m_Center: {x: 0, y: -0.5, z: -0.8}
 --- !u!1 &443873886
 GameObject:
   m_ObjectHideFlags: 0
@@ -513,7 +559,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 2945d0711f6a50c48884056ca8007765, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -642,177 +688,32 @@ Transform:
   m_Father: {fileID: 266593146}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &7479292072466211849
-PrefabInstance:
+--- !u!1 &1993261457 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8894992261763291199, guid: 5ef256b672a4be6488088ec55cea9692, type: 3}
+  m_PrefabInstance: {fileID: 8894992261803742284}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1993261463 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8894992261763291195, guid: 5ef256b672a4be6488088ec55cea9692, type: 3}
+  m_PrefabInstance: {fileID: 8894992261803742284}
+  m_PrefabAsset: {fileID: 0}
+--- !u!54 &1993261464
+Rigidbody:
   m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1993261457}
   serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536466, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7479292071929536478, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
-      propertyPath: m_Name
-      value: BossAttackPlayer
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
---- !u!1001 &7624653079012850649
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 7193736265162846116, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_Name
-      value: BossAttackTurret
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_RootOrder
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -28.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7193736265162846120, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: ae832afb1d689134597e2a8461c0982b, type: 3}
---- !u!1001 &8120450902729634966
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -28.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -23.76
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607664, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2520058075537607676, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
-      propertyPath: m_Name
-      value: BossAttackSpawnMon
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 4
+  m_CollisionDetection: 0
 --- !u!1001 &8894992261803742284
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -841,9 +742,17 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 7479292071929536478, guid: e3e5d80971de54e44a1913cb866d5009, type: 3}
     - target: {fileID: 8894992261763291189, guid: 5ef256b672a4be6488088ec55cea9692, type: 3}
+      propertyPath: Turret.m_Bits
+      value: 2048
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894992261763291189, guid: 5ef256b672a4be6488088ec55cea9692, type: 3}
       propertyPath: monsterAttack
       value: 
       objectReference: {fileID: 2520058075537607676, guid: 6c869653396812841b8233b82e97f2ec, type: 3}
+    - target: {fileID: 8894992261763291192, guid: 5ef256b672a4be6488088ec55cea9692, type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 8894992261763291195, guid: 5ef256b672a4be6488088ec55cea9692, type: 3}
       propertyPath: m_RootOrder
       value: 2
@@ -891,6 +800,10 @@ PrefabInstance:
     - target: {fileID: 8894992261763291199, guid: 5ef256b672a4be6488088ec55cea9692, type: 3}
       propertyPath: m_Name
       value: Boss
+      objectReference: {fileID: 0}
+    - target: {fileID: 8894992263118869873, guid: 5ef256b672a4be6488088ec55cea9692, type: 3}
+      propertyPath: m_Convex
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5ef256b672a4be6488088ec55cea9692, type: 3}

--- a/VR_Toy_Project/Assets/_PJK/Scripts/Boss/BossAttack/BossAttack.cs
+++ b/VR_Toy_Project/Assets/_PJK/Scripts/Boss/BossAttack/BossAttack.cs
@@ -13,8 +13,8 @@ public class BossAttack : MonoBehaviour
 
     private void Awake()
     {
-        boss = GetComponent<GameObject>();
-        bm = GetComponent<BossManager>();
+        boss = this.gameObject;
+       
 
     }
 
@@ -23,7 +23,9 @@ public class BossAttack : MonoBehaviour
     void Update()
     {
        Collider[] colliders= Physics.OverlapSphere(boss.transform.position, 100f, Turret);
-       
+
+
+        Debug.Log(bm.gametime);
         if (bm.gametime == 20)
         {
             attack();

--- a/VR_Toy_Project/Assets/_PJK/Scripts/Boss/BossManager.cs
+++ b/VR_Toy_Project/Assets/_PJK/Scripts/Boss/BossManager.cs
@@ -9,14 +9,15 @@ public class BossManager : MonoBehaviour
     public float elapsedRate = default;
     public float currentTime = default;
     public float gametime = default;
+    public float spawn = default;
     private void Awake()
     {
         instance = this;
     }
     private void Update()
     {
-        
+        spawn += Time.deltaTime;
         gametime += Time.deltaTime;
-        Debug.Log(gametime);
+        //Debug.Log(gametime);
     }
 }

--- a/VR_Toy_Project/Assets/_PJK/Scripts/Boss/BossMoving.cs
+++ b/VR_Toy_Project/Assets/_PJK/Scripts/Boss/BossMoving.cs
@@ -1,22 +1,24 @@
 using System.Collections;
-using System.Collections.Generic;
-using Unity.VisualScripting;
 using UnityEngine;
-using UnityEngine.UIElements;
-using static GrabObject;
 
 public class BossMoving : MonoBehaviour
 {
-    
-    public GameObject boss =default;
-    public GameObject player =default;
 
+    public GameObject boss = default;
+    public GameObject player = default;
+    public GameObject Turret = default;
+    // 터렛을 타겟중인지 체크
+    public bool isFindTurret = false;
+
+    // 터렛을 공격중인지 체크
+    public bool isAttackTurret = false;
+    private Rigidbody rb;
     // Start is called before the first frame update
     void Start()
     {
-        
+
         StartCoroutine(_BossMove());
-        
+
     }
 
     private IEnumerator _BossMove()
@@ -45,6 +47,23 @@ public class BossMoving : MonoBehaviour
             boss.transform.position = newPosition;
             yield return null;
         }
+
+    }
+
+    private void Update()
+    {
+        if (isFindTurret == true)
+        {
+            if (isAttackTurret == true)
+            {
+                //AttackTurret();
+                rb.velocity = Vector3.zero;
+            }
+
+        }
+
+
+
 
     }
 

--- a/VR_Toy_Project/Assets/_PJK/Scripts/Boss/KillAllCollider.cs
+++ b/VR_Toy_Project/Assets/_PJK/Scripts/Boss/KillAllCollider.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+public class KillAllCollider : MonoBehaviour
+{
+    private BossMoving Boss;
+    private GameObject monster;
+    //터렛
+    public GameObject turret = default;
+    private void Awake()
+    {
+        Boss = GetComponentInParent<BossMoving>();
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        Debug.Log(other);
+        if (other.CompareTag("Turret"))
+        {
+            turret = other.gameObject;
+            turret.gameObject.SetActive(false);
+        }
+
+    }
+}

--- a/VR_Toy_Project/Assets/_PJK/Scripts/Boss/KillAllCollider.cs.meta
+++ b/VR_Toy_Project/Assets/_PJK/Scripts/Boss/KillAllCollider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2aac948d4d5dc2a4ea3df6089b8a3ad2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VR_Toy_Project/Assets/_PJK/Scripts/Boss/MonsterSpawner.cs
+++ b/VR_Toy_Project/Assets/_PJK/Scripts/Boss/MonsterSpawner.cs
@@ -21,10 +21,10 @@ public class MonsterSpawner : MonoBehaviour
     private void Update()
     {
         
-        if(BossManager.instance.gametime > spawnTime)
+        if(BossManager.instance.spawn > spawnTime)
         {
             CreateMonster();
-            BossManager.instance.gametime = 0f;
+            BossManager.instance.spawn = 0f;
         }
     }
 

--- a/VR_Toy_Project/Assets/_PJK/Scripts/Monster/DetectedCollider.cs
+++ b/VR_Toy_Project/Assets/_PJK/Scripts/Monster/DetectedCollider.cs
@@ -15,10 +15,20 @@ public class DetectedCollider : MonoBehaviour
     private void OnTriggerEnter(Collider other)
     {
         Debug.Log(other);
-        if(other.CompareTag("Turret"))
+        if (other.CompareTag("Turret"))
         {
             monsterLv1.turret = other.gameObject;
             monsterLv1.isFindTurret = true;
+        }
+
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if(other.CompareTag("Turret"))
+        {
+            monsterLv1.turret = null;
+            monsterLv1.isFindTurret = false;
         }
     }
 }

--- a/VR_Toy_Project/Assets/_PJK/Scripts/Monster/MonsterLv1.cs
+++ b/VR_Toy_Project/Assets/_PJK/Scripts/Monster/MonsterLv1.cs
@@ -1,7 +1,3 @@
-using JetBrains.Annotations;
-using System.Collections;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using UnityEngine;
 
 public class MonsterLv1 : MonoBehaviour
@@ -13,13 +9,13 @@ public class MonsterLv1 : MonoBehaviour
     //터렛
     public GameObject turret = default;
     // 사정거리
-    public float attackdistance = 50f;
-    // 터렛과의 사정거리
-    public float distanceToTurret = 0f;
+    public float attackdistance = 20f;
+    // 터렛과의 거리
+    public float distanceToTurret = default;
     //감지 콜라이더
     public Collider detectCollider = default;
     // 이동 속도
-    public float moveSpeed = 5.0f;
+    public float moveSpeed = 50.0f;
 
     // 터렛을 타겟중인지 체크
     public bool isFindTurret = false;
@@ -44,48 +40,45 @@ public class MonsterLv1 : MonoBehaviour
             // 플레이어 추격
             MoveTowardsTarget(player.transform.position);
         }
-
-        else if(isFindTurret == true)
-        {
-            if (distanceToTurret > 25)
+        // 터렛을 콜라이더에서 발견하면
+        else if (isFindTurret == true)
+        {    //터렛을 공격중이 아니라면
+            if (isAttackTurret == false)
             {
+                // 터렛 추격
+                Vector3 targetPosition = turret.transform.position;
 
 
-                if (isAttackTurret == false)
+                // 현재 위치에서 타겟 방향과 거리 계산
+                Vector3 toTarget = targetPosition - transform.position;
+
+                if (toTarget.magnitude > attackdistance)
                 {
-                    // 터렛 추격
-                    Vector3 targetPosition = turret.transform.position;
-
-
-                    // 현재 위치에서 타겟 방향과 거리 계산
-                    Vector3 toTarget = targetPosition - transform.position;
-
-                    if (toTarget.magnitude > attackdistance)
-                    {
-                        // 이동
-                        MoveTowardsTarget(targetPosition);
-                    }
-
-
-                    // 터렛과의 거리 비교
-                    distanceToTurret = Vector3.Distance(transform.position, turret.transform.position);
-
-                    // 터렛이 사정거리 안에 들어왔다면,
-                    if (distanceToTurret < attackdistance)
-                    {
-
-                        // 터렛 공격
-                        isAttackTurret = true;
-                    }
+                    // 이동
+                    MoveTowardsTarget(targetPosition);
                 }
-            }
-            else
-            {
 
-                AttackTurret();
+
+                // 터렛과의 거리 비교
+                distanceToTurret = Vector3.Distance(transform.position, turret.transform.position);
+
+                // 터렛이 사정거리 안에 들어왔다면,
+                if (distanceToTurret < attackdistance)
+                {
+
+                    // 터렛 공격
+                    isAttackTurret = true;
+                }
+
             }
-            
+            else if(isAttackTurret == true)
+            {
+                //AttackTurret();
+                rb.velocity = Vector3.zero;
+            }
+
         }
+
 
 
 
@@ -105,12 +98,12 @@ public class MonsterLv1 : MonoBehaviour
         // 멈춤
         rb.velocity = Vector3.zero;
         //터렛 공격 함수
-        
-    }
-        
-    
 
-    
+    }
+
+
+
+
 }
 
 


### PR DESCRIPTION
몬스터 움직임을 수정하고
보스의 하위에 콜라이더를 설치해서 보스와 함께움직이며 콜라이더에 닿는 모든 포탑을 삭제시킨다